### PR TITLE
telephony: Check for LTE_CA in physical channel config

### DIFF
--- a/src/java/com/android/internal/telephony/NetworkTypeController.java
+++ b/src/java/com/android/internal/telephony/NetworkTypeController.java
@@ -513,14 +513,26 @@ public class NetworkTypeController extends StateMachine {
         int value = TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NONE;
         if ((getDataNetworkType() == TelephonyManager.NETWORK_TYPE_LTE_CA
                 || mPhone.getServiceState().isUsingCarrierAggregation())
-                && (IntStream.of(mPhone.getServiceState().getCellBandwidths()).sum()
-                        > mLtePlusThresholdBandwidth)) {
+                || isLteCaInPhysicalChannelConfig()
+                // always report LTE+ if available
+                /*&& (IntStream.of(mPhone.getServiceState().getCellBandwidths()).sum()
+                        > mLtePlusThresholdBandwidth)*/) {
             value = TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_LTE_CA;
         }
         if (isLteEnhancedAvailable()) {
             value = TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_LTE_ADVANCED_PRO;
         }
         return value;
+    }
+
+    private boolean isLteCaInPhysicalChannelConfig() {
+        List<PhysicalChannelConfig> physicalChannelConfigList =
+                mPhone.getServiceStateTracker().getPhysicalChannelConfigList();
+        if (ArrayUtils.isEmpty(physicalChannelConfigList)) {
+            return false;
+        }
+        return physicalChannelConfigList.stream()
+                .anyMatch(item -> item.getNetworkType() == TelephonyManager.NETWORK_TYPE_LTE_CA);
     }
 
     private boolean isLteEnhancedAvailable() {


### PR DESCRIPTION
This fixes 4g+ indication on some carriers (such as Vi India with band 8+3 CA). While we're at it, remove the total bandwidth threshold check, as it's unnecessary - for example, 10+10 MHz is still carrier aggregation.

*Self tested in alioth